### PR TITLE
Fix: feature bugs, reliability improvements, and DHCP internet sharing

### DIFF
--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -19,7 +19,9 @@ type dhcpManagerImpl struct {
 	dnsmasqPidFile  string
 	dnsmasqConfFile string
 	leasesFile      string
+	stateFile       string // Persists interface and outInterface for crash recovery
 	currentConfig   *types.DHCPServerConfig
+	outInterface    string // Interface for NAT routing (e.g., wlan0)
 }
 
 // NewDHCPManager creates a new DHCP server manager
@@ -30,6 +32,7 @@ func NewDHCPManager(executor types.SystemExecutor, logger types.Logger) types.DH
 		dnsmasqPidFile:  types.RuntimeDir + "/dnsmasq-dhcp.pid",
 		dnsmasqConfFile: types.RuntimeDir + "/dnsmasq-dhcp.conf",
 		leasesFile:      types.RuntimeDir + "/dnsmasq-dhcp.leases",
+		stateFile:       types.RuntimeDir + "/dhcp-state",
 	}
 }
 
@@ -80,7 +83,14 @@ func (d *dhcpManagerImpl) Start(config *types.DHCPServerConfig) error {
 		return fmt.Errorf("failed to start dnsmasq: %w", err)
 	}
 
+	// Setup NAT/IP forwarding for internet sharing
+	if err := d.setupNAT(config.Interface); err != nil {
+		d.logger.Warn("Failed to setup NAT", "error", err.Error())
+		// Continue anyway - DHCP will work but without internet sharing
+	}
+
 	d.currentConfig = config
+	d.saveState(config.Interface)
 	d.logger.Info("DHCP server started successfully", "interface", config.Interface)
 	return nil
 }
@@ -94,6 +104,18 @@ func (d *dhcpManagerImpl) Stop() error {
 		// (e.g., dnsmasq was killed externally)
 		d.cleanupStaleFiles()
 		return fmt.Errorf("DHCP server is not running")
+	}
+
+	// Recover state from file if needed (e.g., after crash/restart)
+	if d.currentConfig == nil || d.outInterface == "" {
+		d.loadState()
+	}
+
+	// Clean up NAT rules first
+	if d.currentConfig != nil {
+		d.cleanupNAT(d.currentConfig.Interface)
+	} else {
+		d.cleanupNAT("")
 	}
 
 	// Stop dnsmasq
@@ -119,6 +141,8 @@ func (d *dhcpManagerImpl) Stop() error {
 	os.Remove(d.leasesFile)
 
 	d.currentConfig = nil
+	d.outInterface = ""
+	os.Remove(d.stateFile)
 	d.logger.Info("DHCP server stopped successfully")
 	return nil
 }
@@ -260,6 +284,103 @@ func (d *dhcpManagerImpl) generateDnsmasqConfig(config *types.DHCPServerConfig) 
 	}
 
 	return nil
+}
+
+// setupNAT configures IP forwarding and NAT masquerade for internet sharing
+func (d *dhcpManagerImpl) setupNAT(dhcpIface string) error {
+	// Enable IP forwarding
+	if _, err := d.executor.Execute("sh", "-c", "echo 1 > /proc/sys/net/ipv4/ip_forward"); err != nil {
+		return fmt.Errorf("failed to enable IP forwarding: %w", err)
+	}
+
+	// Find outbound interface (excluding the DHCP server interface)
+	outIface := d.detectOutInterface(dhcpIface)
+	if outIface == "" {
+		d.logger.Warn("No outbound interface detected, skipping NAT setup")
+		return nil
+	}
+
+	d.logger.Debug("Setting up NAT", "outInterface", outIface, "dhcpInterface", dhcpIface)
+
+	// Remove existing rules first to prevent duplicates from repeated Start/Stop cycles
+	d.executor.Execute("iptables", "-t", "nat", "-D", "POSTROUTING", "-o", outIface, "-j", "MASQUERADE")
+	d.executor.Execute("iptables", "-D", "FORWARD", "-i", dhcpIface, "-j", "ACCEPT")
+	d.executor.Execute("iptables", "-D", "FORWARD", "-o", dhcpIface, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT")
+
+	// Setup NAT masquerade
+	if _, err := d.executor.Execute("iptables", "-t", "nat", "-A", "POSTROUTING", "-o", outIface, "-j", "MASQUERADE"); err != nil {
+		return fmt.Errorf("failed to setup masquerade: %w", err)
+	}
+
+	// Allow forwarding from DHCP interface
+	if _, err := d.executor.Execute("iptables", "-A", "FORWARD", "-i", dhcpIface, "-j", "ACCEPT"); err != nil {
+		d.logger.Warn("Failed to setup forward rule", "error", err.Error())
+	}
+
+	// Allow established connections back
+	if _, err := d.executor.Execute("iptables", "-A", "FORWARD", "-o", dhcpIface, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"); err != nil {
+		d.logger.Warn("Failed to setup established forward rule", "error", err.Error())
+	}
+
+	d.outInterface = outIface
+	return nil
+}
+
+// detectOutInterface finds the default route interface (excluding the given interface)
+func (d *dhcpManagerImpl) detectOutInterface(exclude string) string {
+	output, err := d.executor.Execute("ip", "route", "show", "default")
+	if err != nil {
+		return ""
+	}
+
+	fields := strings.Fields(output)
+	for i, field := range fields {
+		if field == "dev" && i+1 < len(fields) {
+			iface := fields[i+1]
+			if iface != exclude {
+				return iface
+			}
+		}
+	}
+	return ""
+}
+
+// cleanupNAT removes NAT rules and disables IP forwarding
+func (d *dhcpManagerImpl) cleanupNAT(dhcpIface string) {
+	if d.outInterface != "" {
+		d.executor.Execute("iptables", "-t", "nat", "-D", "POSTROUTING", "-o", d.outInterface, "-j", "MASQUERADE")
+		if dhcpIface != "" {
+			d.executor.Execute("iptables", "-D", "FORWARD", "-i", dhcpIface, "-j", "ACCEPT")
+			d.executor.Execute("iptables", "-D", "FORWARD", "-o", dhcpIface, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT")
+		}
+	}
+
+	if _, err := d.executor.Execute("sh", "-c", "echo 0 > /proc/sys/net/ipv4/ip_forward"); err != nil {
+		d.logger.Warn("Failed to disable IP forwarding", "error", err.Error())
+	}
+}
+
+// saveState persists DHCP interface and outInterface to a state file for crash recovery
+func (d *dhcpManagerImpl) saveState(dhcpIface string) {
+	content := dhcpIface + "|" + d.outInterface
+	if err := os.WriteFile(d.stateFile, []byte(content), 0600); err != nil {
+		d.logger.Debug("Failed to save DHCP state", "error", err)
+	}
+}
+
+// loadState recovers DHCP state from the state file (e.g., after crash/restart)
+func (d *dhcpManagerImpl) loadState() {
+	data, err := os.ReadFile(d.stateFile)
+	if err != nil {
+		return
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(data)), "|", 2)
+	if len(parts) >= 1 && parts[0] != "" && d.currentConfig == nil {
+		d.currentConfig = &types.DHCPServerConfig{Interface: parts[0]}
+	}
+	if len(parts) >= 2 && parts[1] != "" {
+		d.outInterface = parts[1]
+	}
 }
 
 // cleanupStaleFiles removes PID, config, and lease files left behind when

--- a/pkg/dhcp/dhcp_test.go
+++ b/pkg/dhcp/dhcp_test.go
@@ -45,6 +45,7 @@ func startFakeProcess(name string) (string, func()) {
 type mockExecutor struct {
 	commands map[string]string
 	errors   map[string]error
+	called   []string // records all commands executed, in order
 }
 
 func newMockExecutor() *mockExecutor {
@@ -59,6 +60,8 @@ func (m *mockExecutor) Execute(cmd string, args ...string) (string, error) {
 	for _, arg := range args {
 		fullCmd += " " + arg
 	}
+
+	m.called = append(m.called, fullCmd)
 
 	// Check for errors first
 	if err, hasErr := m.errors[fullCmd]; hasErr {
@@ -112,6 +115,7 @@ func setupTestManager() (*dhcpManagerImpl, *mockExecutor) {
 	tmpDir := os.TempDir()
 	mgr.dnsmasqPidFile = filepath.Join(tmpDir, "test_dnsmasq_dhcp.pid")
 	mgr.dnsmasqConfFile = filepath.Join(tmpDir, "test_dnsmasq_dhcp.conf")
+	mgr.stateFile = filepath.Join(tmpDir, "test_dhcp_state")
 
 	return mgr, executor
 }
@@ -119,6 +123,7 @@ func setupTestManager() (*dhcpManagerImpl, *mockExecutor) {
 func cleanup(mgr *dhcpManagerImpl) {
 	os.Remove(mgr.dnsmasqPidFile)
 	os.Remove(mgr.dnsmasqConfFile)
+	os.Remove(mgr.stateFile)
 }
 
 // Tests
@@ -762,6 +767,174 @@ func TestValidateConfig_InvalidDNS(t *testing.T) {
 	err := mgr.Start(config)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid DNS")
+}
+
+// Tests for NAT/IP forwarding (internet sharing)
+
+func TestStart_SetsUpNAT(t *testing.T) {
+	mgr, executor := setupTestManager()
+	defer cleanup(mgr)
+
+	config := &types.DHCPServerConfig{
+		Interface: "eth0",
+		Gateway:   "192.168.100.1",
+		IPRange:   "192.168.100.50,192.168.100.150",
+	}
+
+	// Mock standard commands
+	executor.commands["ip link set eth0 down"] = ""
+	executor.commands["ip link set eth0 up"] = ""
+	executor.commands["ip addr add 192.168.100.1/24 dev eth0"] = ""
+	executor.commands[fmt.Sprintf("dnsmasq -C %s -x %s", mgr.dnsmasqConfFile, mgr.dnsmasqPidFile)] = ""
+
+	// Mock NAT commands - outbound via wlan0
+	executor.commands["ip route show default"] = "default via 192.168.1.1 dev wlan0 proto dhcp"
+	executor.commands["sh -c echo 1 > /proc/sys/net/ipv4/ip_forward"] = ""
+
+	err := mgr.Start(config)
+	assert.NoError(t, err)
+
+	// Verify NAT commands were called
+	assert.Contains(t, executor.called, "sh -c echo 1 > /proc/sys/net/ipv4/ip_forward")
+	assert.Contains(t, executor.called, "iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE")
+	assert.Contains(t, executor.called, "iptables -A FORWARD -i eth0 -j ACCEPT")
+	assert.Contains(t, executor.called, "iptables -A FORWARD -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT")
+}
+
+func TestStart_NATSkippedWhenNoOutboundInterface(t *testing.T) {
+	mgr, executor := setupTestManager()
+	defer cleanup(mgr)
+
+	config := &types.DHCPServerConfig{
+		Interface: "eth0",
+		Gateway:   "192.168.100.1",
+		IPRange:   "192.168.100.50,192.168.100.150",
+	}
+
+	executor.commands["ip link set eth0 down"] = ""
+	executor.commands["ip link set eth0 up"] = ""
+	executor.commands["ip addr add 192.168.100.1/24 dev eth0"] = ""
+	executor.commands[fmt.Sprintf("dnsmasq -C %s -x %s", mgr.dnsmasqConfFile, mgr.dnsmasqPidFile)] = ""
+
+	// No default route - NAT can't be set up but Start should still succeed
+	executor.commands["ip route show default"] = ""
+	executor.commands["sh -c echo 1 > /proc/sys/net/ipv4/ip_forward"] = ""
+
+	err := mgr.Start(config)
+	assert.NoError(t, err)
+
+	// Masquerade should NOT have been called (no outbound interface)
+	for _, cmd := range executor.called {
+		assert.NotContains(t, cmd, "MASQUERADE")
+	}
+}
+
+func TestStart_NATExcludesDHCPInterface(t *testing.T) {
+	mgr, executor := setupTestManager()
+	defer cleanup(mgr)
+
+	// DHCP server on eth0, but default route is also via eth0
+	// Should not use eth0 as outbound — look for the next dev entry
+	config := &types.DHCPServerConfig{
+		Interface: "eth0",
+		Gateway:   "192.168.100.1",
+		IPRange:   "192.168.100.50,192.168.100.150",
+	}
+
+	executor.commands["ip link set eth0 down"] = ""
+	executor.commands["ip link set eth0 up"] = ""
+	executor.commands["ip addr add 192.168.100.1/24 dev eth0"] = ""
+	executor.commands[fmt.Sprintf("dnsmasq -C %s -x %s", mgr.dnsmasqConfFile, mgr.dnsmasqPidFile)] = ""
+
+	// Default route only via eth0 (same as DHCP interface) — no other route
+	executor.commands["ip route show default"] = "default via 192.168.1.1 dev eth0"
+	executor.commands["sh -c echo 1 > /proc/sys/net/ipv4/ip_forward"] = ""
+
+	err := mgr.Start(config)
+	assert.NoError(t, err)
+
+	// Should NOT masquerade to itself
+	for _, cmd := range executor.called {
+		assert.NotContains(t, cmd, "MASQUERADE")
+	}
+}
+
+func TestStop_CleansUpNAT(t *testing.T) {
+	mgr, executor := setupTestManager()
+	defer cleanup(mgr)
+
+	mgr.currentConfig = &types.DHCPServerConfig{
+		Interface: "eth0",
+		Gateway:   "192.168.100.1",
+	}
+	mgr.outInterface = "wlan0"
+
+	// Create fake process
+	dnsmasqPid, cleanDnsmasq := startFakeProcess("dnsmasq")
+	defer cleanDnsmasq()
+	os.WriteFile(mgr.dnsmasqPidFile, []byte(dnsmasqPid), 0644)
+
+	executor.commands["kill "+dnsmasqPid] = ""
+	executor.commands["ip addr flush dev eth0"] = ""
+	executor.commands["ip link set eth0 down"] = ""
+
+	err := mgr.Stop()
+	assert.NoError(t, err)
+
+	// Verify NAT cleanup commands were issued
+	assert.Contains(t, executor.called, "iptables -t nat -D POSTROUTING -o wlan0 -j MASQUERADE")
+	assert.Contains(t, executor.called, "iptables -D FORWARD -i eth0 -j ACCEPT")
+	assert.Contains(t, executor.called, "iptables -D FORWARD -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT")
+	assert.Contains(t, executor.called, "sh -c echo 0 > /proc/sys/net/ipv4/ip_forward")
+}
+
+func TestStop_RecoverStateFromFile(t *testing.T) {
+	mgr, executor := setupTestManager()
+	defer cleanup(mgr)
+
+	// Write state file (simulating crash recovery — no currentConfig or outInterface in memory)
+	os.WriteFile(mgr.stateFile, []byte("eth0|wlan0"), 0600)
+
+	// Create fake process
+	dnsmasqPid, cleanDnsmasq := startFakeProcess("dnsmasq")
+	defer cleanDnsmasq()
+	os.WriteFile(mgr.dnsmasqPidFile, []byte(dnsmasqPid), 0644)
+
+	executor.commands["kill "+dnsmasqPid] = ""
+	executor.commands["ip addr flush dev eth0"] = ""
+	executor.commands["ip link set eth0 down"] = ""
+
+	err := mgr.Stop()
+	assert.NoError(t, err)
+
+	// Should have recovered outInterface from state file and cleaned up NAT
+	assert.Contains(t, executor.called, "iptables -t nat -D POSTROUTING -o wlan0 -j MASQUERADE")
+}
+
+func TestStart_PersistsStateFile(t *testing.T) {
+	mgr, executor := setupTestManager()
+	defer cleanup(mgr)
+
+	config := &types.DHCPServerConfig{
+		Interface: "eth0",
+		Gateway:   "192.168.100.1",
+		IPRange:   "192.168.100.50,192.168.100.150",
+	}
+
+	executor.commands["ip link set eth0 down"] = ""
+	executor.commands["ip link set eth0 up"] = ""
+	executor.commands["ip addr add 192.168.100.1/24 dev eth0"] = ""
+	executor.commands[fmt.Sprintf("dnsmasq -C %s -x %s", mgr.dnsmasqConfFile, mgr.dnsmasqPidFile)] = ""
+	executor.commands["ip route show default"] = "default via 192.168.1.1 dev wlan0"
+	executor.commands["sh -c echo 1 > /proc/sys/net/ipv4/ip_forward"] = ""
+
+	err := mgr.Start(config)
+	assert.NoError(t, err)
+
+	// State file should exist with interface and outbound interface
+	data, err := os.ReadFile(mgr.stateFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "eth0|wlan0", string(data))
 }
 
 func TestStart_WithDifferentNetmasks(t *testing.T) {


### PR DESCRIPTION
## Summary
- **DHCP internet sharing**: Added NAT/IP forwarding to standalone DHCP server — clients now get internet access, not just IPs
- **Tailscale reliability**: Use `tailscale set` instead of `up --reset` to avoid re-auth hangs; suppress spurious warnings on successful switch
- **WiFi/wired fixes**: Teardown WiFi before wired connect to prevent conflicts; fix Tailscale profile switching order
- **Config aliases**: Support network aliases (e.g., `work: home`) for reusing network configs
- **Bug fixes**: Timeouts, WPA3 detection, VPN routing, hotspot validation, dead code removal

## Test plan
- [ ] `go test ./...` passes (verified locally — all 10 packages green)
- [ ] `net dhcp start --interface eth0` — verify client gets IP **and** internet access
- [ ] `net hotspot start` — verify hotspot clients still have internet (regression check)
- [ ] `net connect <alias>` — verify alias resolves to target network
- [ ] `net vpn tailscale <profile>` — verify switch completes without re-auth prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)