### PR TITLE
fix: connection reliability — gateway, DHCP renewal, DNS ownership, wired+WiFi coexistence

### DIFF
--- a/cmd/net/app.go
+++ b/cmd/net/app.go
@@ -311,11 +311,16 @@ func (a *App) RunStop(interfaces []string) error {
 			stoppedServices = append(stoppedServices, "VPN")
 		}
 
-		// Stop network (WiFi/wired)
+		// Stop network (WiFi and wired). WiFi first so wpa_supplicant is
+		// terminated cleanly, then DisconnectAll catches any other active
+		// interfaces (e.g. a wired NIC with a live lease).
 		a.Logger.Debug("Stopping network connection")
-		err = a.WiFiMgr.Disconnect()
-		if err != nil {
-			a.Logger.Error("Failed to disconnect network", "error", err)
+		if err := a.WiFiMgr.Disconnect(); err != nil {
+			a.Logger.Debug("No active WiFi to disconnect", "error", err)
+		}
+		torn := a.NetworkMgr.DisconnectAll()
+		if len(torn) > 0 {
+			stoppedServices = append(stoppedServices, "Network ("+strings.Join(torn, ", ")+")")
 		} else {
 			stoppedServices = append(stoppedServices, "Network")
 		}
@@ -339,12 +344,13 @@ func (a *App) RunStop(interfaces []string) error {
 			a.println("No active services to stop")
 		}
 	} else {
-		// Stop specific interfaces
+		// Stop specific interfaces. Use NetworkMgr.Disconnect so DHCP clients
+		// are killed, addresses/routes flushed, and the link brought down —
+		// otherwise a zombie udhcpc keeps renewing on a down interface.
 		var lastErr error
 		for _, iface := range interfaces {
 			a.Logger.Debug("Stopping interface", "interface", iface)
-			_, err := a.Executor.Execute("ip", "link", "set", iface, "down")
-			if err != nil {
+			if err := a.NetworkMgr.Disconnect(iface); err != nil {
 				a.Logger.Error("Failed to stop interface", "interface", iface, "error", err)
 				a.errorf("✗ Failed to stop %s\n", iface)
 				lastErr = err

--- a/cmd/net/app.go
+++ b/cmd/net/app.go
@@ -325,12 +325,14 @@ func (a *App) RunStop(interfaces []string) error {
 			stoppedServices = append(stoppedServices, "Network")
 		}
 
-		// Clear DNS configuration
+		// Clear DNS configuration, but only if netop set it. If DHCP wrote
+		// resolv.conf and we never locked it, leave it alone — stopping the
+		// network shouldn't wipe out the system's pre-existing DNS state.
 		a.Logger.Debug("Clearing DNS configuration")
-		err = a.NetworkMgr.ClearDNS()
+		cleared, err := a.NetworkMgr.ClearDNSIfOwned()
 		if err != nil {
 			a.Logger.Debug("Failed to clear DNS", "error", err)
-		} else {
+		} else if cleared {
 			stoppedServices = append(stoppedServices, "DNS")
 		}
 

--- a/cmd/net/app_test.go
+++ b/cmd/net/app_test.go
@@ -249,6 +249,14 @@ func (n *testNetworkManager) GetConnectionInfo(iface string) (*types.Connection,
 	return &types.Connection{Interface: iface, State: "connected"}, nil
 }
 
+func (n *testNetworkManager) Disconnect(iface string) error {
+	return nil
+}
+
+func (n *testNetworkManager) DisconnectAll() []string {
+	return nil
+}
+
 // testHotspotManager implements types.HotspotManager for testing
 type testHotspotManager struct {
 	status    *types.HotspotStatus

--- a/cmd/net/app_test.go
+++ b/cmd/net/app_test.go
@@ -238,7 +238,7 @@ func (n *testNetworkManager) StartDHCP(iface string, hostname string) error {
 	return nil
 }
 
-func (n *testNetworkManager) SetIP(iface, addr, gateway string) error {
+func (n *testNetworkManager) SetIP(iface, addr, gateway string, metric int) error {
 	return nil
 }
 

--- a/cmd/net/app_test.go
+++ b/cmd/net/app_test.go
@@ -207,6 +207,10 @@ func (n *testNetworkManager) ClearDNS() error {
 	return nil
 }
 
+func (n *testNetworkManager) ClearDNSIfOwned() (bool, error) {
+	return false, nil
+}
+
 func (n *testNetworkManager) LockDNS() {
 }
 

--- a/pkg/dhcpclient/dhcpclient.go
+++ b/pkg/dhcpclient/dhcpclient.go
@@ -5,6 +5,7 @@ package dhcpclient
 import (
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -114,7 +115,23 @@ func (m *Manager) Release(iface string) error {
 	// Escape regex special characters in interface name (e.g., eth-0 has '-' which is a regex char)
 	escapedIface := regexp.QuoteMeta(iface)
 
-	// Kill both DHCP clients to ensure cleanup
+	// Prefer graceful shutdown via pidfile: SIGTERM lets udhcpc send a
+	// DHCPRELEASE (via -R) and clean up the lease on the server side. Fall
+	// back to pkill -9 if pidfile is missing or the process is already dead.
+	pidFile := udhcpcPidFile(iface)
+	if data, err := os.ReadFile(pidFile); err == nil {
+		pid := strings.TrimSpace(string(data))
+		if pid != "" {
+			if _, err := m.executor.ExecuteWithTimeout(CleanupTimeout, "kill", pid); err != nil {
+				m.logger.Debug("Failed to SIGTERM udhcpc via pidfile", "pid", pid, "error", err)
+			}
+		}
+		_ = os.Remove(pidFile)
+	}
+
+	// Backstop: kill any udhcpc/dhclient still matching the interface. This
+	// catches daemons started outside of netop or leftover processes from a
+	// crashed run.
 	if _, err := m.executor.ExecuteWithTimeout(CleanupTimeout, "pkill", "-9", "-f", "udhcpc.*"+escapedIface); err != nil {
 		m.logger.Debug("No udhcpc process to kill", "interface", iface)
 	}
@@ -153,14 +170,28 @@ func (m *Manager) Renew(iface string, hostname string) error {
 	return m.Acquire(iface, hostname)
 }
 
-// acquireUdhcpc uses udhcpc (BusyBox) for faster DHCP acquisition
+// udhcpcPidFile returns the pidfile path for udhcpc on the given interface.
+func udhcpcPidFile(iface string) string {
+	return types.RuntimeDir + "/udhcpc." + iface + ".pid"
+}
+
+// acquireUdhcpc uses udhcpc (BusyBox) for faster DHCP acquisition.
+// udhcpc daemonizes after obtaining the lease and stays alive to handle
+// renewals. The PID is written to /run/net/udhcpc.<iface>.pid so Release
+// can terminate it cleanly (which sends a DHCPRELEASE via -R).
 func (m *Manager) acquireUdhcpc(iface string, hostname string) error {
 	// Release any existing clients first
 	m.Release(iface)
 
-	// Build udhcpc command
-	// -i: interface, -n: fail if no lease (don't go to background), -q: quit after obtaining lease
-	args := []string{"-i", iface, "-n", "-q"}
+	// -i: interface
+	// -n: exit if no lease acquired (so Acquire returns error on failure)
+	// -p: pidfile so Release can find and kill the daemon
+	// -R: send DHCPRELEASE when terminated (clean disconnect)
+	// -B: set the broadcast flag in DISCOVER. Some embedded DHCP servers
+	//     (e.g. IP radios, WISP gear) only reply via broadcast and silently
+	//     drop clients that ask for unicast.
+	// NOTE: no -q — udhcpc must stay running to renew the lease.
+	args := []string{"-i", iface, "-n", "-p", udhcpcPidFile(iface), "-R", "-B"}
 	if hostname != "" {
 		m.logger.Info("Sending hostname in DHCP request", "hostname", hostname)
 		args = append(args, "-x", "hostname:"+hostname)

--- a/pkg/dhcpclient/dhcpclient_test.go
+++ b/pkg/dhcpclient/dhcpclient_test.go
@@ -211,14 +211,14 @@ func TestAcquire_UsesUdhcpcWhenAvailable(t *testing.T) {
 	executor.commands["pkill -9 -f dhclient.*wlan0"] = ""
 	executor.commands["rm -f /var/lib/dhcp/dhclient.wlan0.leases /run/net/dhclient.wlan0.leases"] = ""
 	executor.commands["rm -f /run/net/dhclient.wlan0.conf"] = ""
-	executor.commands["udhcpc -i wlan0 -n -q"] = ""
+	executor.commands["udhcpc -i wlan0 -n -p /run/net/udhcpc.wlan0.pid -R -B"] = ""
 	executor.commands["ip addr show wlan0"] = "inet 192.168.1.50/24"
 	logger := &mockLogger{}
 	manager := NewManager(executor, logger)
 
 	err := manager.Acquire("wlan0", "")
 	assert.NoError(t, err)
-	executor.assertCommandExecuted(t, "udhcpc -i wlan0 -n -q")
+	executor.assertCommandExecuted(t, "udhcpc -i wlan0 -n -p /run/net/udhcpc.wlan0.pid -R -B")
 	// Note: pkill for dhclient is still called during Release() cleanup,
 	// but actual dhclient command (timeout 15 dhclient -v) is not executed
 	executor.assertCommandNotExecuted(t, "timeout 15 dhclient")
@@ -249,7 +249,7 @@ func TestAcquire_WithHostname_Udhcpc(t *testing.T) {
 	executor.commands["pkill -9 -f dhclient.*wlan0"] = ""
 	executor.commands["rm -f /var/lib/dhcp/dhclient.wlan0.leases /run/net/dhclient.wlan0.leases"] = ""
 	executor.commands["rm -f /run/net/dhclient.wlan0.conf"] = ""
-	executor.commands["udhcpc -i wlan0 -n -q -x hostname:myhost"] = ""
+	executor.commands["udhcpc -i wlan0 -n -p /run/net/udhcpc.wlan0.pid -R -B -x hostname:myhost"] = ""
 	executor.commands["ip addr show wlan0"] = "inet 192.168.1.50/24"
 	logger := &mockLogger{}
 	manager := NewManager(executor, logger)
@@ -515,7 +515,7 @@ func TestAcquire_CleansUpOnUdhcpcFailure(t *testing.T) {
 	executor.commands["rm -f /var/lib/dhcp/dhclient.wlan0.leases"] = ""
 	executor.commands["rm -f /run/net/dhclient.wlan0.leases"] = ""
 	executor.commands["rm -f /run/net/dhclient.wlan0.conf"] = ""
-	executor.errors["udhcpc -i wlan0 -n -q"] = errors.New("no lease obtained")
+	executor.errors["udhcpc -i wlan0 -n -p /run/net/udhcpc.wlan0.pid -R -B"] = errors.New("no lease obtained")
 	logger := &mockLogger{}
 	manager := NewManager(executor, logger)
 

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -238,6 +238,11 @@ func (m *Manager) SetIP(iface, addr, gateway string) error {
 			return fmt.Errorf("invalid gateway %q: must be a valid IP address", gateway)
 		}
 
+		// Remove any pre-existing default route on this interface so `ip route
+		// add` doesn't fail with "File exists" on reconnects. Errors here are
+		// expected (often no route to delete) and ignored.
+		m.executor.ExecuteWithTimeout(5*time.Second, "ip", "route", "del", "default", "dev", iface)
+
 		// Add default route
 		_, err = m.executor.ExecuteWithTimeout(5*time.Second, "ip", "route", "add", "default", "via", gateway, "dev", iface)
 		if err != nil {
@@ -767,6 +772,67 @@ func (m *Manager) GetConnectionInfo(iface string) (*types.Connection, error) {
 		Gateway:   gateway,
 		DNS:       dns,
 	}, nil
+}
+
+// Disconnect releases DHCP, flushes addresses and routes, and brings the link
+// down for a single interface. Safe to call on interfaces that are already
+// down or have no configuration.
+func (m *Manager) Disconnect(iface string) error {
+	if err := types.ValidateInterfaceName(iface); err != nil {
+		return fmt.Errorf("invalid interface: %w", err)
+	}
+	m.logger.Info("Disconnecting interface", "interface", iface)
+
+	if m.dhcpClient != nil {
+		_ = m.dhcpClient.Release(iface)
+	}
+	m.executor.Execute("ip", "addr", "flush", "dev", iface)
+	m.executor.Execute("ip", "route", "flush", "dev", iface)
+	if _, err := m.executor.Execute("ip", "link", "set", iface, "down"); err != nil {
+		return fmt.Errorf("failed to bring interface down: %w", err)
+	}
+	return nil
+}
+
+// DisconnectAll tears down every physical interface (wired or wireless) that
+// currently has an IPv4 address. Virtual interfaces (lo, docker*, veth*, br*,
+// wg*, tun*, tailscale*) are skipped. Returns the list of interfaces torn down.
+func (m *Manager) DisconnectAll() []string {
+	var torn []string
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		m.logger.Debug("Failed to list interfaces", "error", err)
+		return torn
+	}
+	for _, iface := range ifaces {
+		name := iface.Name
+		if name == "lo" || strings.HasPrefix(name, "docker") ||
+			strings.HasPrefix(name, "veth") || strings.HasPrefix(name, "br") ||
+			strings.HasPrefix(name, "wg") || strings.HasPrefix(name, "tun") ||
+			strings.HasPrefix(name, "tailscale") || strings.HasPrefix(name, "virbr") {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		hasIPv4 := false
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.To4() != nil && !ipnet.IP.IsLinkLocalUnicast() {
+				hasIPv4 = true
+				break
+			}
+		}
+		if !hasIPv4 {
+			continue
+		}
+		if err := m.Disconnect(name); err != nil {
+			m.logger.Warn("Failed to disconnect interface", "interface", name, "error", err)
+			continue
+		}
+		torn = append(torn, name)
+	}
+	return torn
 }
 
 // parseGateway extracts the default gateway from ip route output

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,23 +15,53 @@ import (
 
 // Manager implements the NetworkManager interface
 type Manager struct {
-	executor   types.SystemExecutor
-	logger     types.Logger
-	dhcpClient types.DHCPClientManager
+	executor         types.SystemExecutor
+	logger           types.Logger
+	dhcpClient       types.DHCPClientManager
+	dnsOwnershipPath string // overridable for tests; defaults to types.RuntimeDir/dns-owned
 }
 
 // NewManager creates a new network manager
 func NewManager(executor types.SystemExecutor, logger types.Logger, dhcpClient types.DHCPClientManager) *Manager {
 	return &Manager{
-		executor:   executor,
-		logger:     logger,
-		dhcpClient: dhcpClient,
+		executor:         executor,
+		logger:           logger,
+		dhcpClient:       dhcpClient,
+		dnsOwnershipPath: types.RuntimeDir + "/dns-owned",
 	}
 }
 
 // killProcess kills processes matching a pattern with SIGKILL (fast, no graceful shutdown)
 func (m *Manager) killProcess(pattern string) {
 	system.KillProcessFast(m.executor, m.logger, pattern)
+}
+
+// dnsOwnedPath returns the marker file indicating netop owns /etc/resolv.conf.
+// When present, ClearDNS will clear resolv.conf on disconnect; when absent
+// (DNS came from DHCP and we never locked it), ClearDNS is a no-op so we
+// don't nuke DNS that was there before netop started.
+func (m *Manager) dnsOwnedPath() string {
+	if m.dnsOwnershipPath != "" {
+		return m.dnsOwnershipPath
+	}
+	return types.RuntimeDir + "/dns-owned"
+}
+
+func (m *Manager) markDNSOwned() {
+	path := m.dnsOwnedPath()
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+		m.logger.Debug("Failed to mark DNS ownership", "error", err)
+	}
+}
+
+func (m *Manager) clearDNSOwnership() {
+	_ = os.Remove(m.dnsOwnedPath())
+}
+
+func (m *Manager) isDNSOwned() bool {
+	_, err := os.Stat(m.dnsOwnedPath())
+	return err == nil
 }
 
 // SetDNS configures DNS servers
@@ -41,6 +72,7 @@ func (m *Manager) SetDNS(servers []string) error {
 		if err != nil {
 			m.logger.Debug("Failed to remove immutable flag (may not be set)", "error", err)
 		}
+		m.clearDNSOwnership()
 		m.logger.Info("Using DHCP for DNS configuration")
 		return nil
 	}
@@ -77,26 +109,50 @@ func (m *Manager) SetDNS(servers []string) error {
 	if err != nil {
 		m.logger.Warn("Failed to lock resolv.conf", "error", err)
 	}
+	m.markDNSOwned()
 
 	return nil
 }
 
-// ClearDNS clears the DNS configuration by removing /etc/resolv.conf
+// ClearDNS clears /etc/resolv.conf, but only if netop wrote it. If DNS was
+// provided by DHCP and never locked by us, we leave it alone so `net stop`
+// doesn't wipe out DNS that the user had before netop ran.
 func (m *Manager) ClearDNS() error {
+	cleared, err := m.clearDNS()
+	if err != nil {
+		return err
+	}
+	if !cleared {
+		m.logger.Debug("DNS not owned by netop, leaving resolv.conf alone")
+	}
+	return nil
+}
+
+// ClearDNSIfOwned clears resolv.conf only if netop set it, returning whether
+// anything was actually changed. Used by `net stop` to avoid printing a
+// misleading "DNS cleared" line when netop never owned DNS in the first place.
+func (m *Manager) ClearDNSIfOwned() (bool, error) {
+	return m.clearDNS()
+}
+
+func (m *Manager) clearDNS() (bool, error) {
 	m.logger.Debug("Clearing DNS configuration")
+
+	if !m.isDNSOwned() {
+		return false, nil
+	}
 
 	if err := m.unlockResolvConf(); err != nil {
 		m.logger.Warn("Failed to unlock resolv.conf", "error", err)
 	}
 
-	// Clear the file by writing an empty configuration
-	err := m.writeFileDirect("/etc/resolv.conf", "# DNS cleared by net\n")
-	if err != nil {
-		return fmt.Errorf("failed to clear resolv.conf: %w", err)
+	if err := m.writeFileDirect("/etc/resolv.conf", "# DNS cleared by net\n"); err != nil {
+		return false, fmt.Errorf("failed to clear resolv.conf: %w", err)
 	}
+	m.clearDNSOwnership()
 
 	m.logger.Debug("DNS configuration cleared")
-	return nil
+	return true, nil
 }
 
 // LockDNS sets the immutable flag on /etc/resolv.conf to prevent external
@@ -105,6 +161,7 @@ func (m *Manager) LockDNS() {
 	if _, err := m.executor.Execute("chattr", "+i", "/etc/resolv.conf"); err != nil {
 		m.logger.Warn("Failed to lock resolv.conf", "error", err)
 	}
+	m.markDNSOwned()
 }
 
 // unlockResolvConf removes the immutable flag from /etc/resolv.conf.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -196,9 +196,10 @@ func (m *Manager) GetMAC(iface string) (string, error) {
 	return "", fmt.Errorf("MAC address not found in interface output")
 }
 
-// SetIP sets IP address and gateway
-func (m *Manager) SetIP(iface, addr, gateway string) error {
-	m.logger.Info("Setting IP configuration", "interface", iface, "addr", addr, "gateway", gateway)
+// SetIP sets IP address and gateway. If metric > 0, it is applied to the default
+// route; otherwise the kernel default is used.
+func (m *Manager) SetIP(iface, addr, gateway string, metric int) error {
+	m.logger.Info("Setting IP configuration", "interface", iface, "addr", addr, "gateway", gateway, "metric", metric)
 	m.logger.Debug("SetIP using wireless interface", "interface", iface)
 
 	// Validate interface name
@@ -243,8 +244,13 @@ func (m *Manager) SetIP(iface, addr, gateway string) error {
 		// expected (often no route to delete) and ignored.
 		m.executor.ExecuteWithTimeout(5*time.Second, "ip", "route", "del", "default", "dev", iface)
 
-		// Add default route
-		_, err = m.executor.ExecuteWithTimeout(5*time.Second, "ip", "route", "add", "default", "via", gateway, "dev", iface)
+		// Add default route, with metric when set so multiple links coexist
+		// deterministically (lower metric wins).
+		args := []string{"route", "add", "default", "via", gateway, "dev", iface}
+		if metric > 0 {
+			args = append(args, "metric", fmt.Sprintf("%d", metric))
+		}
+		_, err = m.executor.ExecuteWithTimeout(5*time.Second, "ip", args...)
 		if err != nil {
 			return fmt.Errorf("failed to set gateway: %w", err)
 		}
@@ -638,6 +644,9 @@ func (m *Manager) ConnectToConfiguredNetwork(config *types.NetworkConfig, passwo
 				return fmt.Errorf("failed to connect to WiFi: %w", err)
 			}
 		}
+		// WiFi DHCP installs a default route without a metric; re-add with metric
+		// so a concurrently-connected wired interface (lower metric) takes priority.
+		m.applyDefaultRouteMetric(config.Interface, config.DefaultRouteMetric())
 	} else {
 		m.logger.Debug("No SSID specified in network config - treating as wired connection")
 
@@ -674,6 +683,8 @@ func (m *Manager) ConnectToConfiguredNetwork(config *types.NetworkConfig, passwo
 				err := m.StartDHCP(config.Interface, config.Hostname)
 				if err != nil {
 					m.logger.Warn("Failed to obtain DHCP on wired interface", "interface", config.Interface, "error", err)
+				} else {
+					m.applyDefaultRouteMetric(config.Interface, config.DefaultRouteMetric())
 				}
 			}
 		}
@@ -682,7 +693,7 @@ func (m *Manager) ConnectToConfiguredNetwork(config *types.NetworkConfig, passwo
 	// Set static IP if configured
 	if config.Addr != "" {
 		m.logger.Debug("Setting static IP from config", "addr", config.Addr, "gateway", config.Gateway)
-		err := m.SetIP(config.Interface, config.Addr, config.Gateway)
+		err := m.SetIP(config.Interface, config.Addr, config.Gateway, config.DefaultRouteMetric())
 		if err != nil {
 			return fmt.Errorf("failed to set IP: %w", err)
 		}
@@ -772,6 +783,45 @@ func (m *Manager) GetConnectionInfo(iface string) (*types.Connection, error) {
 		Gateway:   gateway,
 		DNS:       dns,
 	}, nil
+}
+
+// applyDefaultRouteMetric finds the DHCP-installed default route on iface and
+// re-adds it with the given metric. DHCP clients (udhcpc/dhclient) install
+// default routes without metrics, so when two interfaces are up simultaneously
+// the kernel picks by insertion order instead of a deterministic priority.
+// This re-installs with metric so wired wins over WiFi (or vice versa per config).
+func (m *Manager) applyDefaultRouteMetric(iface string, metric int) {
+	if metric <= 0 {
+		return
+	}
+	output, err := m.executor.Execute("ip", "route", "show", "default", "dev", iface)
+	if err != nil || strings.TrimSpace(output) == "" {
+		return
+	}
+	// Parse "default via 10.1.0.1 dev enx... [metric N]" — grab the gateway.
+	fields := strings.Fields(output)
+	var gateway string
+	for i, f := range fields {
+		if f == "via" && i+1 < len(fields) {
+			gateway = fields[i+1]
+			break
+		}
+	}
+	if gateway == "" {
+		m.logger.Debug("No gateway in default route, skipping metric", "iface", iface, "route", output)
+		return
+	}
+	// Check if metric is already set to the desired value — avoid churn.
+	for i, f := range fields {
+		if f == "metric" && i+1 < len(fields) && fields[i+1] == fmt.Sprintf("%d", metric) {
+			return
+		}
+	}
+	m.logger.Debug("Applying default route metric", "iface", iface, "gateway", gateway, "metric", metric)
+	m.executor.Execute("ip", "route", "del", "default", "dev", iface)
+	if _, err := m.executor.Execute("ip", "route", "add", "default", "via", gateway, "dev", iface, "metric", fmt.Sprintf("%d", metric)); err != nil {
+		m.logger.Warn("Failed to reinstall default route with metric", "iface", iface, "error", err)
+	}
 }
 
 // Disconnect releases DHCP, flushes addresses and routes, and brings the link

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -1135,12 +1135,18 @@ func (m *mockWiFiManagerImpl) GetInterface() string {
 // ============================================================================
 
 func TestClearDNS(t *testing.T) {
-	t.Run("success - removes immutable attribute", func(t *testing.T) {
+	t.Run("success - removes immutable attribute when netop owns DNS", func(t *testing.T) {
 		executor := newMockExecutor()
 		executor.commands["chattr -i /etc/resolv.conf"] = ""
 		executor.commands["tee /etc/resolv.conf"] = ""
 		logger := &mockLogger{}
-		manager := &Manager{executor: executor, logger: logger}
+		manager := &Manager{
+			executor:         executor,
+			logger:           logger,
+			dnsOwnershipPath: t.TempDir() + "/dns-owned",
+		}
+
+		manager.markDNSOwned()
 
 		err := manager.ClearDNS()
 		assert.NoError(t, err)
@@ -1152,11 +1158,33 @@ func TestClearDNS(t *testing.T) {
 		executor.errors["chattr -i /etc/resolv.conf"] = fmt.Errorf("Operation not supported")
 		executor.commands["tee /etc/resolv.conf"] = ""
 		logger := &mockLogger{}
-		manager := &Manager{executor: executor, logger: logger}
+		manager := &Manager{
+			executor:         executor,
+			logger:           logger,
+			dnsOwnershipPath: t.TempDir() + "/dns-owned",
+		}
+
+		manager.markDNSOwned()
 
 		// Should still succeed - chattr failure is expected on some filesystems
 		err := manager.ClearDNS()
 		assert.NoError(t, err)
+	})
+
+	t.Run("no-op when netop does not own DNS", func(t *testing.T) {
+		executor := newMockExecutor()
+		logger := &mockLogger{}
+		manager := &Manager{
+			executor:         executor,
+			logger:           logger,
+			dnsOwnershipPath: t.TempDir() + "/dns-owned",
+		}
+
+		// No markDNSOwned() call — DNS is not owned by netop
+		err := manager.ClearDNS()
+		assert.NoError(t, err)
+		// Should NOT have touched resolv.conf
+		executor.assertCommandNotExecuted(t, "chattr -i /etc/resolv.conf")
 	})
 }
 

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -487,6 +487,7 @@ func TestSetIP(t *testing.T) {
 		executor := newStrictMockExecutor()
 		executor.commands["ip addr flush dev wlan0"] = ""
 		executor.commands["ip addr add 192.168.1.100/24 dev wlan0"] = ""
+		executor.commands["ip route del default dev wlan0"] = ""
 		executor.commands["ip route add default via 192.168.1.1 dev wlan0"] = ""
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
@@ -494,11 +495,12 @@ func TestSetIP(t *testing.T) {
 		err := manager.SetIP("wlan0", "192.168.1.100/24", "192.168.1.1")
 		assert.NoError(t, err)
 
-		// Verify commands executed in order: flush, add addr, add route
-		assert.Len(t, executor.executedCmds, 3)
+		// Verify commands executed in order: flush addr, add addr, del default (idempotent), add route
+		assert.Len(t, executor.executedCmds, 4)
 		assert.Equal(t, "ip addr flush dev wlan0", executor.executedCmds[0])
 		assert.Equal(t, "ip addr add 192.168.1.100/24 dev wlan0", executor.executedCmds[1])
-		assert.Equal(t, "ip route add default via 192.168.1.1 dev wlan0", executor.executedCmds[2])
+		assert.Equal(t, "ip route del default dev wlan0", executor.executedCmds[2])
+		assert.Equal(t, "ip route add default via 192.168.1.1 dev wlan0", executor.executedCmds[3])
 	})
 }
 

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -492,7 +492,7 @@ func TestSetIP(t *testing.T) {
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
-		err := manager.SetIP("wlan0", "192.168.1.100/24", "192.168.1.1")
+		err := manager.SetIP("wlan0", "192.168.1.100/24", "192.168.1.1", 0)
 		assert.NoError(t, err)
 
 		// Verify commands executed in order: flush addr, add addr, del default (idempotent), add route
@@ -914,7 +914,8 @@ func TestConnectToConfiguredNetwork(t *testing.T) {
 		executor.commands["ip link set eth0 up"] = ""
 		executor.commands["ip addr flush dev eth0"] = ""
 		executor.commands["ip addr add 192.168.1.100/24 dev eth0"] = ""
-		executor.commands["ip route add default via 192.168.1.1 dev eth0"] = ""
+		executor.commands["ip route del default dev eth0"] = ""
+		executor.commands["ip route add default via 192.168.1.1 dev eth0 metric 100"] = ""
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
@@ -927,7 +928,7 @@ func TestConnectToConfiguredNetwork(t *testing.T) {
 		err := manager.ConnectToConfiguredNetwork(config, "", nil)
 		assert.NoError(t, err)
 		executor.assertCommandExecuted(t, "ip addr add 192.168.1.100/24 dev eth0")
-		executor.assertCommandExecuted(t, "ip route add default via 192.168.1.1 dev eth0")
+		executor.assertCommandExecuted(t, "ip route add default via 192.168.1.1 dev eth0 metric 100")
 	})
 
 	t.Run("with custom routes", func(t *testing.T) {
@@ -1282,7 +1283,7 @@ func TestSetIP_ErrorPaths(t *testing.T) {
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
-		err := manager.SetIP("eth0", "192.168.1.100/24", "192.168.1.1")
+		err := manager.SetIP("eth0", "192.168.1.100/24", "192.168.1.1", 0)
 		assert.NoError(t, err) // Flush failure is just logged, not returned
 	})
 
@@ -1298,7 +1299,7 @@ func TestSetIP_ErrorPaths(t *testing.T) {
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
-		err := manager.SetIP("eth0", "192.168.1.100/24", "192.168.1.1")
+		err := manager.SetIP("eth0", "192.168.1.100/24", "192.168.1.1", 0)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to set IP address")
 	})
@@ -1316,7 +1317,7 @@ func TestSetIP_ErrorPaths(t *testing.T) {
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
-		err := manager.SetIP("eth0", "192.168.1.100/24", "192.168.1.1")
+		err := manager.SetIP("eth0", "192.168.1.100/24", "192.168.1.1", 0)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to set gateway")
 	})
@@ -1331,7 +1332,7 @@ func TestSetIP_ErrorPaths(t *testing.T) {
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
-		err := manager.SetIP("eth0", "192.168.1.100/24", "")
+		err := manager.SetIP("eth0", "192.168.1.100/24", "", 0)
 		assert.NoError(t, err)
 	})
 
@@ -1345,7 +1346,7 @@ func TestSetIP_ErrorPaths(t *testing.T) {
 		logger := &mockLogger{}
 		manager := &Manager{executor: executor, logger: logger}
 
-		err := manager.SetIP("eth0", "", "192.168.1.1")
+		err := manager.SetIP("eth0", "", "192.168.1.1", 0)
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -221,6 +221,8 @@ type VPNManager interface {
 type NetworkManager interface {
 	SetDNS(servers []string) error
 	ClearDNS() error
+	// ClearDNSIfOwned clears DNS only if netop set it. Returns (cleared, err).
+	ClearDNSIfOwned() (bool, error)
 	LockDNS()
 	SetMAC(iface, mac string) error
 	GetMAC(iface string) (string, error)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -102,6 +102,22 @@ type NetworkConfig struct {
 	MAC       string   `yaml:"mac" mapstructure:"mac"`
 	Hostname  string   `yaml:"hostname" mapstructure:"hostname"`
 	VPN       string   `yaml:"vpn" mapstructure:"vpn"`
+	// Metric is the default-route metric (lower = preferred). 0 means use the
+	// built-in default (100 for wired, 600 for WiFi) so wired wins when both
+	// are up simultaneously. Matches NetworkManager's default convention.
+	Metric int `yaml:"metric" mapstructure:"metric"`
+}
+
+// DefaultRouteMetric returns the default-route metric for this network,
+// falling back to type-appropriate defaults when Metric is 0.
+func (n *NetworkConfig) DefaultRouteMetric() int {
+	if n.Metric > 0 {
+		return n.Metric
+	}
+	if n.SSID != "" {
+		return 600
+	}
+	return 100
 }
 
 // WiFiNetwork represents a discovered WiFi network
@@ -208,7 +224,7 @@ type NetworkManager interface {
 	LockDNS()
 	SetMAC(iface, mac string) error
 	GetMAC(iface string) (string, error)
-	SetIP(iface, addr, gateway string) error
+	SetIP(iface, addr, gateway string, metric int) error
 	AddRoute(iface, destination, gateway string) error
 	FlushRoutes(iface string) error
 	StartDHCP(iface string, hostname string) error

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -215,6 +215,13 @@ type NetworkManager interface {
 	DHCPRenew(iface string, hostname string) error
 	ConnectToConfiguredNetwork(config *NetworkConfig, password string, wifiMgr WiFiManager) error
 	GetConnectionInfo(iface string) (*Connection, error)
+	// Disconnect releases DHCP, flushes addresses/routes, and brings the link down
+	// for a single interface. Safe to call on an already-down interface.
+	Disconnect(iface string) error
+	// DisconnectAll tears down every non-loopback/non-virtual interface that has
+	// an IPv4 address assigned. Used by `net stop` to clean up both wired and WiFi.
+	// Returns the list of interfaces that were torn down.
+	DisconnectAll() []string
 }
 
 // ConfigManager handles configuration loading and management


### PR DESCRIPTION
## Summary

Fixes a cluster of connection-reliability bugs around gateway/DNS/IP lifecycle, uncovered while debugging an IP-radio wired link that wouldn't acquire a lease and wouldn't renew.

The 4 commits in this PR (on top of the earlier work already on the branch):

1. **`udhcpc broadcast flag + daemon mode`** — `-B` flag fixes embedded DHCP servers (IP radios, WISP gear) that only reply to broadcast DISCOVERs. Dropping `-q` and adding `-p <pidfile> -R` keeps udhcpc alive for lease renewals and shuts it down cleanly via DHCPRELEASE.
2. **`net stop tears down all active interfaces`** — RunStop only called `WiFiMgr.Disconnect()`, leaving wired IPs, default routes, and udhcpc daemons alive. New `NetworkManager.Disconnect(iface)` and `DisconnectAll()` release DHCP, flush addresses/routes, and bring links down. `SetIP` now removes any pre-existing default route before adding a new one, fixing silent reconnect failures.
3. **`default route metrics`** — running wired and WiFi simultaneously was non-deterministic because DHCP clients install defaults without metrics. Added `NetworkConfig.Metric` (YAML `metric:`) with sensible type-based defaults (100 wired, 600 WiFi — lower wins, matches NetworkManager). `applyDefaultRouteMetric()` post-processes the DHCP-installed route.
4. **`DNS ownership tracking`** — `net stop` was wiping `/etc/resolv.conf` even when netop had never set DNS, leaving the system with no resolver. Marker file at `/run/net/dns-owned` tracks ownership; `ClearDNSIfOwned()` is a no-op when unmarked.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` all packages green (includes the 40s network + 30s VPN integration suites)
- [ ] Manual: `net wired` on the IP radio that previously failed → should get a lease (broadcast flag) and hold it past 120s (renewal)
- [ ] Manual: `net wired` then `net <wifi>` → `ip route` shows both defaults with metric 100 (wired) and 600 (WiFi), kernel prefers wired
- [ ] Manual: `net stop` when wired is up → wired interface brought down, udhcpc killed, DHCPRELEASE sent
- [ ] Manual: `net stop` when only DHCP wrote DNS → resolv.conf left alone, not wiped

🤖 Generated with [Claude Code](https://claude.com/claude-code)